### PR TITLE
resolve vulnerability version DJ

### DIFF
--- a/vanzare/requirements/base.txt
+++ b/vanzare/requirements/base.txt
@@ -1,6 +1,6 @@
 appdirs==1.4.3
 cffi==1.10.0
-Django==1.11.1
+Django==1.11.15
 django-widget-tweaks==1.4.1
 django-wkhtmltopdf==3.1.0
 netifaces==0.10.6


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-14574
https://github.com/PyBAQ/vanzare/network/alert/vanzare/requirements/base.txt/django/open

CVE-2018-14574 More information
moderate severity
Vulnerable versions: >= 1.11.0, < 1.11.15
Patched version: 1.11.15
django.middleware.common.CommonMiddleware in Django 1.11.x before 1.11.15 and 2.0.x before 2.0.8 has an Open Redirect.
